### PR TITLE
⬆️ Upgrade t-digest codec to version 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
           <groupId>com.tdunning</groupId>
           <artifactId>t-digest</artifactId>
-          <version>3.1</version>
+          <version>3.2</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/src/main/java/net/opentsdb/core/MergingTDigestImplementation.java
+++ b/src/main/java/net/opentsdb/core/MergingTDigestImplementation.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
-import com.tdunning.math.stats.AVLTreeDigest;
+import com.tdunning.math.stats.MergingDigest;
 import com.tdunning.math.stats.TDigest;
 
 import net.opentsdb.core.Histogram;
@@ -80,7 +80,7 @@ public class MergingTDigestImplementation implements Histogram {
       encoded = raw;
     }
     final ByteBuffer buf = ByteBuffer.wrap(encoded);
-    digest = AVLTreeDigest.fromBytes(buf);
+    digest = MergingDigest.fromBytes(buf);
   }
 
   public double percentile(double p) {

--- a/src/test/java/net/opentsdb/core/TestMergingTDigestCodec.java
+++ b/src/test/java/net/opentsdb/core/TestMergingTDigestCodec.java
@@ -47,7 +47,7 @@ private TDigest digest;
     final byte[] raw = buf.array();
     Histogram histo = codec.decode(raw, false);
     assertArrayEquals(raw, histo.histogram(false));
-    assertEquals(40.649, histo.percentile(95.0), 0.001);
+    assertEquals(42.5, histo.percentile(95.0), 0.001);
     
     byte[] with_id = new byte[raw.length + 1];
     with_id[0] = 42;
@@ -55,7 +55,7 @@ private TDigest digest;
     histo = codec.decode(raw, false);
     assertArrayEquals(raw, histo.histogram(false));
     assertArrayEquals(with_id, histo.histogram(true));
-    assertEquals(40.649, histo.percentile(95.0), 0.001);
+    assertEquals(42.5, histo.percentile(95.0), 0.001);
     
     try {
       codec.decode(null, false);

--- a/src/test/java/net/opentsdb/core/TestMergingTDigestImplementation.java
+++ b/src/test/java/net/opentsdb/core/TestMergingTDigestImplementation.java
@@ -93,14 +93,14 @@ public class TestMergingTDigestImplementation {
     byte[] raw = buf.array();
     
     histo.fromHistogram(raw, false);
-    assertEquals(40.649, histo.percentile(95.0), 0.001);
+    assertEquals(42.5, histo.percentile(95.0), 0.001);
     
     byte[] with_id = new byte[raw.length + 1];
     with_id[0] = 42;
     System.arraycopy(raw, 0, with_id, 1, raw.length);
     
     histo.fromHistogram(with_id, true);
-    assertEquals(40.649, histo.percentile(95.0), 0.001);
+    assertEquals(42.5, histo.percentile(95.0), 0.001);
     
     try {
       histo.fromHistogram(new byte[] { 0, 0, 0, 2, 64, 89, 0, 0, 0, 0, 0, 0, 
@@ -131,7 +131,7 @@ public class TestMergingTDigestImplementation {
         new MergingTDigestImplementation(42);
     histo.setDigest(digest);
     
-    assertEquals(40.649, histo.percentile(95.0), 0.001);
+    assertEquals(42.5, histo.percentile(95.0), 0.001);
     assertEquals(24.0, histo.percentile(50.0), 0.001);
     assertEquals(1.0, histo.percentile(0.0), 0.001);
     
@@ -157,7 +157,7 @@ public class TestMergingTDigestImplementation {
     assertEquals(3, percentiles.size());
     assertEquals(1.0, percentiles.get(0), 0.001);
     assertEquals(24.0, percentiles.get(1), 0.001);
-    assertEquals(40.649, percentiles.get(2), 0.001);
+    assertEquals(42.5, percentiles.get(2), 0.001);
     
     try {
       histo.percentiles(Lists.<Double>newArrayList(0D, -1D, 95.0D));
@@ -206,7 +206,7 @@ public class TestMergingTDigestImplementation {
         (MergingTDigestImplementation) histo.clone();
     assertNotSame(histo, copy);
     assertNotSame(histo.getDigest(), copy.getDigest());
-    assertEquals(40.649, histo.percentile(95.0), 0.001);
+    assertEquals(42.5, histo.percentile(95.0), 0.001);
   }
   
   @Test
@@ -226,7 +226,7 @@ public class TestMergingTDigestImplementation {
     
     histo.aggregate(histo2, HistogramAggregation.SUM);
     
-    assertEquals(77.6, histo.percentile(95.0), 0.01);
+    assertEquals(89.3, histo.percentile(95.0), 0.01);
     assertEquals(19.5, histo.percentile(50.0), 0.01);
     assertEquals(1.0, histo.percentile(0.0), 0.01);
     
@@ -264,7 +264,7 @@ public class TestMergingTDigestImplementation {
     histo.aggregate(Lists.<Histogram>newArrayList(histo2, histo3), 
         HistogramAggregation.SUM);
     
-    assertEquals(70.579, histo.percentile(95.0), 0.001);
+    assertEquals(89.3, histo.percentile(95.0), 0.001);
     assertEquals(22.4, histo.percentile(50.0), 0.01);
     assertEquals(1.0, histo.percentile(0.0), 0.01);
     


### PR DESCRIPTION
Upgrades the t-digest codec to version 3.2 which is more than [two years newer](https://github.com/tdunning/t-digest/compare/e97591a53b70cd25f642dfed64b849e3f99e2b2f...e7c7cb1805f8bc2add78295a11b025bf249688c0) than the previous 3.1. There have been significant improvements in [these changes](https://github.com/tdunning/t-digest/blob/b9d555b394a3fb8bf813193be5cb763ce5854128/RELEASE-NOTES.md) in performance and precision.

Closes: #1